### PR TITLE
feat: Support the show subcommand and fix CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,7 +30,7 @@ jobs:
           push: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:latest
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}-next
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}-next
             ${{ github.repository }}:${{ github.sha }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -48,7 +48,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}-next
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}-next
       - name: Template action metadata file
         shell: bash
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ jobs:
   release:
     permissions:
       packages: write
+      contents: write
 
     name: Create GitHub release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
       - main
 jobs:
   release:
+    permissions:
+      packages: write
+
     name: Create GitHub release
     runs-on: ubuntu-latest
     steps:
@@ -51,8 +54,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:latest
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ github.sha }}
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}
       - name: Template action metadata file
         shell: bash
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,8 @@ jobs:
           push: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:latest
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ github.sha }}
-            ghcr.io/ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/terragrunt-github-actions:${{ steps.version.outputs.new_version }}
             ${{ github.repository_owner }}/terragrunt-github-actions:${{ github.sha }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,7 @@ jobs:
         shell: bash
         env:
           GIT_TAG: "${{ steps.version.outputs.new_version }}"
+          GITHUB_OWNER: "${{ github.repository_owner }}"
         run: |
           make template
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ template:
 		GIT_TAG=$$(git rev-parse HEAD); \
 		export GIT_TAG; \
 	fi && \
-	docker run -e GIT_TAG -v $$PWD:/workspace hairyhenderson/gomplate:stable -f /workspace/action.yml.tpl -o /workspace/action.yml
+	docker run -e GIT_TAG -e GITHUB_OWNER -v $$PWD:/workspace hairyhenderson/gomplate:stable -f /workspace/action.yml.tpl -o /workspace/action.yml

--- a/action.yml
+++ b/action.yml
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:0.0.1'
+  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:0.0.2'

--- a/action.yml
+++ b/action.yml
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.1.0'
+  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:0.0.1'

--- a/action.yml
+++ b/action.yml
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io//terragrunt-github-actions:0.0.3'
+  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:0.0.4'

--- a/action.yml
+++ b/action.yml
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:0.0.2'
+  image: 'docker://ghcr.io//terragrunt-github-actions:0.0.3'

--- a/action.yml.tpl
+++ b/action.yml.tpl
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'
+  image: 'docker://ghcr.io/{{ getenv "GITHUB_OWNER" }}/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'

--- a/action.yml.tpl
+++ b/action.yml.tpl
@@ -57,4 +57,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'
+  image: 'docker://ghcr.io/wwsean08/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'

--- a/src/main.sh
+++ b/src/main.sh
@@ -230,6 +230,7 @@ function main {
     show)
       installTerragrunt
       terragruntShow ${*}
+      ;;
     *)
       echo "Error: Must provide a valid value for terragrunt_subcommand"
       exit 1

--- a/src/main.sh
+++ b/src/main.sh
@@ -182,6 +182,7 @@ function main {
   source ${scriptDir}/terragrunt_import.sh
   source ${scriptDir}/terragrunt_taint.sh
   source ${scriptDir}/terragrunt_destroy.sh
+  source ${scriptDir}/terragrunt_show.sh
 
   parseInputs
   configureCLICredentials
@@ -226,6 +227,9 @@ function main {
       installTerragrunt
       terragruntDestroy ${*}
       ;;
+    show)
+      installTerragrunt
+      terragruntShow ${*}
     *)
       echo "Error: Must provide a valid value for terragrunt_subcommand"
       exit 1

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -5,15 +5,12 @@ function terragruntShow {
   echo "show: info: planning Terragrunt configuration in ${tfWorkingDir}"
   showOutput=$(${tfBinary} show ${*})
   showExitCode=${?}
-  planHasChanges=false
-  planCommentStatus="Failed"
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then
     echo "plan: info: successfully showing Terragrunt configuration in ${tfWorkingDir}"
     echo "${showOutput}"
     echo
-    echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
 
   else
     echo "show: error: failed to show Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -3,7 +3,7 @@
 function terragruntShow {
   # Gather the output of `terragrunt plan`.
   echo "show: info: planning Terragrunt configuration in ${tfWorkingDir}"
-  showOutput=$(${tfBinary} show ${*} 2>&1)
+  showOutput=$(${tfBinary} show ${*})
   showExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function terragruntShow {
+  # Gather the output of `terragrunt plan`.
+  echo "show: info: planning Terragrunt configuration in ${tfWorkingDir}"
+  showOutput=$(${tfBinary} show ${*} 2>&1)
+  showExitCode=${?}
+  planHasChanges=false
+  planCommentStatus="Failed"
+
+  # Exit code of 0 indicates success with no changes. Print the output and exit.
+  if [ ${showExitCode} -eq 0 ]; then
+    echo "plan: info: successfully showing Terragrunt configuration in ${tfWorkingDir}"
+    echo "${showOutput}"
+    echo
+    echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+
+  else
+    echo "show: error: failed to show Terragrunt configuration in ${tfWorkingDir}"
+    echo "${showOutput}"
+    echo
+  fi
+
+  exit ${showExitCode}
+}

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -9,7 +9,8 @@ function terragruntShow {
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then
     echo "plan: info: successfully showing Terragrunt configuration in ${tfWorkingDir}"
-    echo "${showOutput}"
+    echo ${showOutput}
+    echo "tf_actions_output=${showOutput}" >> $GITHUB_OUTPUT
     echo
 
   else


### PR DESCRIPTION
This adds the following features:
* Support the `show` subcommand in order to be able to get access to the json version of the plan
* Update the workflow so that the image can automatically be created in any users account without updating the template
* Update permissions used by the release workflow
* Fix some invalid URLs