### PR TITLE
fix: pass arguments to show_json command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.4.0'
+  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.4.1-next'

--- a/src/main.sh
+++ b/src/main.sh
@@ -237,7 +237,7 @@ function main {
       ;;
     show_json)
       installTerragrunt
-      terragruntJsonFile
+      terragruntJsonFile ${*}
       ;;
     *)
       echo "Error: Must provide a valid value for terragrunt_subcommand"


### PR DESCRIPTION
This fixes an issue where additional arguments are not passed to the 'showJson' command, causing plan file outputs to not be properly translated into JSON.