### PR TITLE
feat: python3, PyYAML, and fix for older output method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh uuidgen"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh python3 py3-pip uuidgen"]
+RUN ["pip", "install", "PyYAML==6.0"]
 
 ## Addresses https://avd.aquasec.com/nvd/cve-2022-40674
 RUN apk add --no-cache expat>2.4.9-r0

--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.4.2-next'
+  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.0-next'

--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ outputs:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.4.1'
+  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.4.2-next'

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -67,12 +67,12 @@ ${fmtComment}
   fi
 
   # Write changes to branch
-  echo "::set-output name=tf_actions_fmt_written::false"
+  echo "tf_actions_fmt_written=false" >> ${GITHUB_OUTPUT}
   if [ "${tfFmtWrite}" == "1" ]; then
     echo "fmt: info: Terraform files in ${tfWorkingDir} will be formatted"
     terraform fmt -write=true ${fmtRecursive} "${*}"
     fmtExitCode=${?}
-    echo "::set-output name=tf_actions_fmt_written::true"
+    echo "tf_actions_fmt_written=true" >> ${GITHUB_OUTPUT}
   fi
 
   exit ${fmtExitCode}

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -17,7 +17,7 @@ function terragruntOutput {
     outputOutput="${outputOutput//$'\n'/'%0A'}"
     outputOutput="${outputOutput//$'\r'/'%0D'}"
 
-    echo "::set-output name=tf_actions_output::${outputOutput}"
+    echo "tf_actions_output='${outputOutput}'" >> ${GITHUB_OUTPUT}
     exit ${outputExitCode}
   fi
 

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -13,7 +13,7 @@ function terragruntPlan {
     echo "plan: info: successfully planned Terragrunt configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
-    echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+    echo "tf_actions_plan_has_changes=${planHasChanges}" >> ${GITHUB_OUTPUT}
     exit ${planExitCode}
   fi
 
@@ -63,13 +63,13 @@ ${planOutput}
     echo "${planPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${planCommentsURL}" > /dev/null
   fi
 
-  echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+  echo "tf_actions_plan_has_changes=${planHasChanges}" >> ${GITHUB_OUTPUT}
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
   planOutput="${planOutput//'%'/'%25'}"
   planOutput="${planOutput//$'\n'/'%0A'}"
   planOutput="${planOutput//$'\r'/'%0D'}"
 
-  echo "::set-output name=tf_actions_plan_output::${planOutput}"
+  echo "tf_actions_plan_output='${planOutput}'" >> ${GITHUB_OUTPUT}
   exit ${planExitCode}
 }


### PR DESCRIPTION
* Updates the Action to use the newer method of setting output values, since the older `set-ouput` command has been deprecated.
* Adds python and the PyYAML library to the base image, which may be useful for folks doing unusual things with Terraform external data sources.