### PR TITLE
terraform directory output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,8 @@ outputs:
     description: 'The Terragrunt plan output.'
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
+  tf_actions_terraform_dir:
+    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.1-next'

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,10 @@ outputs:
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
   tf_actions_terraform_dir:
-    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
+    description: >
+      The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.
+      Note that if the Action has been run multiple times with different input values it is possible that there
+      may be multiple values returned.
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.1-next'

--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,6 @@ outputs:
     description: 'The Terragrunt plan output.'
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
-  tf_actions_terraform_dir:
-    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.0'
+  image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.1-next'

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,8 @@ outputs:
     description: 'The Terragrunt plan output.'
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
+  tf_actions_terraform_dir:
+    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/yardbirdsax/terragrunt-github-actions:1.5.0'

--- a/action.yml.tpl
+++ b/action.yml.tpl
@@ -69,6 +69,8 @@ outputs:
     description: 'The Terragrunt plan output.'
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
+  tf_actions_terraform_dir:
+    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/{{ getenv "GITHUB_OWNER" }}/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'

--- a/action.yml.tpl
+++ b/action.yml.tpl
@@ -70,7 +70,10 @@ outputs:
   tf_actions_fmt_written:
     description: 'Whether or not the Terragrunt formatting was written to source files.'
   tf_actions_terraform_dir:
-    description: 'The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.'
+    description: >
+      The path that terragrunt used as the base path for executing terraform.  Contains the .terraform dir.
+      Note that if the Action has been run multiple times with different input values it is possible that there
+      may be multiple values returned.
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/{{ getenv "GITHUB_OWNER" }}/terragrunt-github-actions:{{ getenv "GIT_TAG" }}'

--- a/src/main.sh
+++ b/src/main.sh
@@ -205,47 +205,47 @@ function main {
   case "${tfSubcommand}" in
     fmt)
       installTerragrunt
-      mainExitCode=$(terragruntFmt ${*})
+      terragruntFmt ${*}
       ;;
     init)
       installTerragrunt
-      mainExitCode=$(terragruntInit ${*})
+      terragruntInit ${*}
       ;;
     validate)
       installTerragrunt
-      mainExitCode=$(terragruntValidate ${*})
+      terragruntValidate ${*}
       ;;
     plan)
       installTerragrunt
-      mainExitCode=$(terragruntPlan ${*})
+      terragruntPlan ${*}
       ;;
     apply)
       installTerragrunt
-      mainExitCode=$(terragruntApply ${*})
+      terragruntApply ${*}
       ;;
     output)
       installTerragrunt
-      mainExitCode=$(terragruntOutput ${*})
+      terragruntOutput ${*}
       ;;
     import)
       installTerragrunt
-      mainExitCode=$(terragruntImport ${*})
+      terragruntImport ${*}
       ;;
     taint)
       installTerragrunt
-      mainExitCode=$(terragruntTaint ${*})
+      terragruntTaint ${*}
       ;;
     destroy)
       installTerragrunt
-      mainExitCode=$(terragruntDestroy ${*})
+      terragruntDestroy ${*}
       ;;
     show)
       installTerragrunt
-      mainExitCode=$(terragruntShow ${*})
+      terragruntShow ${*}
       ;;
     show_json)
       installTerragrunt
-      mainExitCode=$(terragruntJsonFile ${*})
+      terragruntJsonFile ${*}
       ;;
     *)
       echo "Error: Must provide a valid value for terragrunt_subcommand"

--- a/src/main.sh
+++ b/src/main.sh
@@ -173,6 +173,12 @@ function executePreCommands {
   fi
 }
 
+function findTerraformDir {
+  local dot_terraform_dir=$(find ".terragrunt-cache" -type d -name ".terraform")
+  local terraform_dir=$(dirname $tf_dir)
+  echo "$terraform_dir"
+}
+
 function main {
   # Source the other files to gain access to their functions
   scriptDir=$(dirname ${0})

--- a/src/main.sh
+++ b/src/main.sh
@@ -175,7 +175,7 @@ function executePreCommands {
 
 function findTerraformDir {
   local dot_terraform_dir=$(find ".terragrunt-cache" -type d -name ".terraform")
-  local terraform_dir=$(dirname $tf_dir)
+  local terraform_dir=$(dirname $dot_terraform_dir)
   echo "$terraform_dir"
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -256,7 +256,7 @@ function main {
   # Process the working dir if we have a non-errored exit code
   if [ ${mainExitCode} -ne 1 ]; then
     # Pass the directory used for processing terraform to the outputs
-    terraformDir=$(findTerraformDir)
+    terraformDir="$(findTerraformDir)"
     echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
   fi
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -200,56 +200,68 @@ function main {
   executePreCommands
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
+  mainExitCode=0
+
   case "${tfSubcommand}" in
     fmt)
       installTerragrunt
-      terragruntFmt ${*}
+      mainExitCode=$(terragruntFmt ${*})
       ;;
     init)
       installTerragrunt
-      terragruntInit ${*}
+      mainExitCode=$(terragruntInit ${*})
       ;;
     validate)
       installTerragrunt
-      terragruntValidate ${*}
+      mainExitCode=$(terragruntValidate ${*})
       ;;
     plan)
       installTerragrunt
-      terragruntPlan ${*}
+      mainExitCode=$(terragruntPlan ${*})
       ;;
     apply)
       installTerragrunt
-      terragruntApply ${*}
+      mainExitCode=$(terragruntApply ${*})
       ;;
     output)
       installTerragrunt
-      terragruntOutput ${*}
+      mainExitCode=$(terragruntOutput ${*})
       ;;
     import)
       installTerragrunt
-      terragruntImport ${*}
+      mainExitCode=$(terragruntImport ${*})
       ;;
     taint)
       installTerragrunt
-      terragruntTaint ${*}
+      mainExitCode=$(terragruntTaint ${*})
       ;;
     destroy)
       installTerragrunt
-      terragruntDestroy ${*}
+      mainExitCode=$(terragruntDestroy ${*})
       ;;
     show)
       installTerragrunt
-      terragruntShow ${*}
+      mainExitCode=$(terragruntShow ${*})
       ;;
     show_json)
       installTerragrunt
-      terragruntJsonFile ${*}
+      mainExitCode=$(terragruntJsonFile ${*})
       ;;
     *)
       echo "Error: Must provide a valid value for terragrunt_subcommand"
-      exit 1
+      mainExitCode=1
       ;;
   esac
+
+  # Process the working dir if we have a non-errored exit code
+  if [ ${mainExitCode} -ne 1 ]; then
+    # Pass the directory used for processing terraform to the outputs
+    terraformDir=$(findTerraformDir)
+    echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
+  fi
+
+  # Exit with the exit code derived in a function call
+  exit ${mainExitCode}
 }
 
 main "${*}"

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -7,10 +7,6 @@ function terragruntApply {
   applyExitCode=${?}
   applyCommentStatus="Failed"
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${applyExitCode} -eq 0 ]; then
     echo "apply: info: successfully applied Terragrunt configuration in ${tfWorkingDir}"
@@ -47,5 +43,5 @@ ${applyOutput}
     echo "${applyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${applyCommentsURL}" > /dev/null
   fi
 
-  exit ${applyExitCode}
+  return ${applyExitCode}
 }

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -7,6 +7,10 @@ function terragruntApply {
   applyExitCode=${?}
   applyCommentStatus="Failed"
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${applyExitCode} -eq 0 ]; then
     echo "apply: info: successfully applied Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -43,5 +43,5 @@ ${applyOutput}
     echo "${applyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${applyCommentsURL}" > /dev/null
   fi
 
-  return ${applyExitCode}
+  mainExitCode=${applyExitCode}
 }

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -9,7 +9,7 @@ function terragruntApply {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${applyExitCode} -eq 0 ]; then

--- a/src/terragrunt_destroy.sh
+++ b/src/terragrunt_destroy.sh
@@ -7,10 +7,6 @@ function terragruntDestroy {
   destroyExitCode=${?}
   destroyCommentStatus="Failed"
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${destroyExitCode} -eq 0 ]; then
     echo "destroy: info: successfully destroyed Terragrunt-managed infrastructure in ${tfWorkingDir}"
@@ -47,5 +43,5 @@ ${destroyOutput}
     echo "${destroyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${destroyCommentsURL}" > /dev/null
   fi
 
-  exit ${destroyExitCode}
+  return ${destroyExitCode}
 }

--- a/src/terragrunt_destroy.sh
+++ b/src/terragrunt_destroy.sh
@@ -9,7 +9,7 @@ function terragruntDestroy {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${destroyExitCode} -eq 0 ]; then

--- a/src/terragrunt_destroy.sh
+++ b/src/terragrunt_destroy.sh
@@ -7,6 +7,10 @@ function terragruntDestroy {
   destroyExitCode=${?}
   destroyCommentStatus="Failed"
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${destroyExitCode} -eq 0 ]; then
     echo "destroy: info: successfully destroyed Terragrunt-managed infrastructure in ${tfWorkingDir}"

--- a/src/terragrunt_destroy.sh
+++ b/src/terragrunt_destroy.sh
@@ -43,5 +43,5 @@ ${destroyOutput}
     echo "${destroyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${destroyCommentsURL}" > /dev/null
   fi
 
-  return ${destroyExitCode}
+  mainExitCode=${destroyExitCode}
 }

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -17,7 +17,8 @@ function terragruntFmt {
     echo "fmt: info: Terragrunt files in ${tfWorkingDir} are correctly formatted"
     echo "${fmtOutput}"
     echo
-    return ${fmtExitCode}
+    mainExitCode=${fmtExitCode}
+    return
   fi
 
   # Exit code of 2 indicates a parse error. Print the output and exit.
@@ -25,7 +26,8 @@ function terragruntFmt {
     echo "fmt: error: failed to parse Terragrunt files"
     echo "${fmtOutput}"
     echo
-    return ${fmtExitCode}
+    mainExitCode=${fmtExitCode}
+    return
   fi
 
   # Exit code of !0 and !2 indicates failure.
@@ -75,5 +77,5 @@ ${fmtComment}
     echo "tf_actions_fmt_written=true" >> ${GITHUB_OUTPUT}
   fi
 
-  return ${fmtExitCode}
+  mainExitCode=${fmtExitCode}
 }

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -14,7 +14,7 @@ function terragruntFmt {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${fmtExitCode} -eq 0 ]; then

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -12,6 +12,10 @@ function terragruntFmt {
   fmtOutput=$(${tfBinary} fmt -check=true -write=false -diff ${fmtRecursive} ${*} 2>&1)
   fmtExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${fmtExitCode} -eq 0 ]; then
     echo "fmt: info: Terragrunt files in ${tfWorkingDir} are correctly formatted"

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -12,16 +12,12 @@ function terragruntFmt {
   fmtOutput=$(${tfBinary} fmt -check=true -write=false -diff ${fmtRecursive} ${*} 2>&1)
   fmtExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${fmtExitCode} -eq 0 ]; then
     echo "fmt: info: Terragrunt files in ${tfWorkingDir} are correctly formatted"
     echo "${fmtOutput}"
     echo
-    exit ${fmtExitCode}
+    return ${fmtExitCode}
   fi
 
   # Exit code of 2 indicates a parse error. Print the output and exit.
@@ -29,7 +25,7 @@ function terragruntFmt {
     echo "fmt: error: failed to parse Terragrunt files"
     echo "${fmtOutput}"
     echo
-    exit ${fmtExitCode}
+    return ${fmtExitCode}
   fi
 
   # Exit code of !0 and !2 indicates failure.
@@ -79,5 +75,5 @@ ${fmtComment}
     echo "tf_actions_fmt_written=true" >> ${GITHUB_OUTPUT}
   fi
 
-  exit ${fmtExitCode}
+  return ${fmtExitCode}
 }

--- a/src/terragrunt_import.sh
+++ b/src/terragrunt_import.sh
@@ -7,6 +7,10 @@ function terragruntImport {
   importExitCode=${?}
   importCommentStatus="Failed"
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${importExitCode} -eq 0 ]; then
     echo "import: info: successfully imported Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_import.sh
+++ b/src/terragrunt_import.sh
@@ -9,7 +9,7 @@ function terragruntImport {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${importExitCode} -eq 0 ]; then

--- a/src/terragrunt_import.sh
+++ b/src/terragrunt_import.sh
@@ -7,16 +7,12 @@ function terragruntImport {
   importExitCode=${?}
   importCommentStatus="Failed"
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${importExitCode} -eq 0 ]; then
     echo "import: info: successfully imported Terragrunt configuration in ${tfWorkingDir}"
     echo "${importOutput}"
     echo
-    exit ${importExitCode}
+    return ${importExitCode}
   fi
 
   # Exit code of !0 indicates failure.
@@ -47,5 +43,5 @@ ${importOutput}
     echo "${importPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${importCommentsURL}" > /dev/null
   fi
 
-  exit ${importExitCode}
+  return ${importExitCode}
 }

--- a/src/terragrunt_import.sh
+++ b/src/terragrunt_import.sh
@@ -12,7 +12,8 @@ function terragruntImport {
     echo "import: info: successfully imported Terragrunt configuration in ${tfWorkingDir}"
     echo "${importOutput}"
     echo
-    return ${importExitCode}
+    mainExitCode=${importExitCode}
+    return
   fi
 
   # Exit code of !0 indicates failure.
@@ -43,5 +44,5 @@ ${importOutput}
     echo "${importPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${importCommentsURL}" > /dev/null
   fi
 
-  return ${importExitCode}
+  mainExitCode=${importExitCode}
 }

--- a/src/terragrunt_init.sh
+++ b/src/terragrunt_init.sh
@@ -8,7 +8,7 @@ function terragruntInit {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${initExitCode} -eq 0 ]; then

--- a/src/terragrunt_init.sh
+++ b/src/terragrunt_init.sh
@@ -11,7 +11,8 @@ function terragruntInit {
     echo "init: info: successfully initialized Terragrunt configuration in ${tfWorkingDir}"
     echo "${initOutput}"
     echo
-    return ${initExitCode}
+    mainExitCode=${initExitCode}
+    return
   fi
 
   # Exit code of !0 indicates failure.
@@ -37,5 +38,5 @@ ${initOutput}
     echo "${initPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${initCommentsURL}" > /dev/null
   fi
 
-  return ${initExitCode}
+  mainExitCode=${initExitCode}
 }

--- a/src/terragrunt_init.sh
+++ b/src/terragrunt_init.sh
@@ -6,6 +6,10 @@ function terragruntInit {
   initOutput=$(${tfBinary} init -input=false ${*} 2>&1)
   initExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${initExitCode} -eq 0 ]; then
     echo "init: info: successfully initialized Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_init.sh
+++ b/src/terragrunt_init.sh
@@ -6,16 +6,12 @@ function terragruntInit {
   initOutput=$(${tfBinary} init -input=false ${*} 2>&1)
   initExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${initExitCode} -eq 0 ]; then
     echo "init: info: successfully initialized Terragrunt configuration in ${tfWorkingDir}"
     echo "${initOutput}"
     echo
-    exit ${initExitCode}
+    return ${initExitCode}
   fi
 
   # Exit code of !0 indicates failure.
@@ -41,5 +37,5 @@ ${initOutput}
     echo "${initPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${initCommentsURL}" > /dev/null
   fi
 
-  exit ${initExitCode}
+  return ${initExitCode}
 }

--- a/src/terragrunt_json_file.sh
+++ b/src/terragrunt_json_file.sh
@@ -5,5 +5,9 @@ function terragruntJsonFile {
   ${tfBinary} show -json ${*} > tf_plan.json
   showExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   exit ${showExitCode}
 }

--- a/src/terragrunt_json_file.sh
+++ b/src/terragrunt_json_file.sh
@@ -7,7 +7,7 @@ function terragruntJsonFile {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   exit ${showExitCode}
 }

--- a/src/terragrunt_json_file.sh
+++ b/src/terragrunt_json_file.sh
@@ -5,5 +5,5 @@ function terragruntJsonFile {
   ${tfBinary} show -json ${*} > tf_plan.json
   showExitCode=${?}
 
-  return ${showExitCode}
+  mainExitCode=${showExitCode}
 }

--- a/src/terragrunt_json_file.sh
+++ b/src/terragrunt_json_file.sh
@@ -5,9 +5,5 @@ function terragruntJsonFile {
   ${tfBinary} show -json ${*} > tf_plan.json
   showExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
-  exit ${showExitCode}
+  return ${showExitCode}
 }

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -18,12 +18,13 @@ function terragruntOutput {
     outputOutput="${outputOutput//$'\r'/'%0D'}"
 
     echo "tf_actions_output='${outputOutput}'" >> ${GITHUB_OUTPUT}
-    return ${outputExitCode}
+    mainExitCode=${outputExitCode}
+    return
   fi
 
   # Exit code of !0 indicates failure.
   echo "output: error: failed to gather all the outputs for the Terragrunt configuration in ${tfWorkingDir}"
   echo "${outputOutput}"
   echo
-  return ${outputExitCode}
+  mainExitCode=${outputExitCode}
 }

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -6,6 +6,10 @@ function terragruntOutput {
   outputOutput=$(${tfBinary} output -json ${*} 2>&1)
   outputExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${outputExitCode} -eq 0 ]; then
     echo "output: info: successfully gathered all the outputs for the Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -8,7 +8,7 @@ function terragruntOutput {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${outputExitCode} -eq 0 ]; then

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -6,10 +6,6 @@ function terragruntOutput {
   outputOutput=$(${tfBinary} output -json ${*} 2>&1)
   outputExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${outputExitCode} -eq 0 ]; then
     echo "output: info: successfully gathered all the outputs for the Terragrunt configuration in ${tfWorkingDir}"
@@ -22,12 +18,12 @@ function terragruntOutput {
     outputOutput="${outputOutput//$'\r'/'%0D'}"
 
     echo "tf_actions_output='${outputOutput}'" >> ${GITHUB_OUTPUT}
-    exit ${outputExitCode}
+    return ${outputExitCode}
   fi
 
   # Exit code of !0 indicates failure.
   echo "output: error: failed to gather all the outputs for the Terragrunt configuration in ${tfWorkingDir}"
   echo "${outputOutput}"
   echo
-  exit ${outputExitCode}
+  return ${outputExitCode}
 }

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -8,17 +8,13 @@ function terragruntPlan {
   planHasChanges=false
   planCommentStatus="Failed"
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${planExitCode} -eq 0 ]; then
     echo "plan: info: successfully planned Terragrunt configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
     echo "tf_actions_plan_has_changes=${planHasChanges}" >> ${GITHUB_OUTPUT}
-    exit ${planExitCode}
+    return ${planExitCode}
   fi
 
   # Exit code of 2 indicates success with changes. Print the output, change the
@@ -75,5 +71,5 @@ ${planOutput}
   planOutput="${planOutput//$'\r'/'%0D'}"
 
   echo "tf_actions_plan_output='${planOutput}'" >> ${GITHUB_OUTPUT}
-  exit ${planExitCode}
+  return ${planExitCode}
 }

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -10,7 +10,7 @@ function terragruntPlan {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${planExitCode} -eq 0 ]; then

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -8,6 +8,10 @@ function terragruntPlan {
   planHasChanges=false
   planCommentStatus="Failed"
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${planExitCode} -eq 0 ]; then
     echo "plan: info: successfully planned Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -14,7 +14,7 @@ function terragruntPlan {
     echo "${planOutput}"
     echo
     echo "tf_actions_plan_has_changes=${planHasChanges}" >> ${GITHUB_OUTPUT}
-    return ${planExitCode}
+    mainExitCode=${planExitCode}
   fi
 
   # Exit code of 2 indicates success with changes. Print the output, change the
@@ -71,5 +71,5 @@ ${planOutput}
   planOutput="${planOutput//$'\r'/'%0D'}"
 
   echo "tf_actions_plan_output='${planOutput}'" >> ${GITHUB_OUTPUT}
-  return ${planExitCode}
+  mainExitCode=${planExitCode}
 }

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -6,10 +6,6 @@ function terragruntShow {
   showOutput=$(${tfBinary} show ${*})
   showExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then
     echo "plan: info: successfully showing Terragrunt configuration in ${tfWorkingDir}"
@@ -23,5 +19,5 @@ function terragruntShow {
     echo
   fi
 
-  exit ${showExitCode}
+  return ${showExitCode}
 }

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -6,6 +6,10 @@ function terragruntShow {
   showOutput=$(${tfBinary} show ${*})
   showExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then
     echo "plan: info: successfully showing Terragrunt configuration in ${tfWorkingDir}"

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -19,5 +19,5 @@ function terragruntShow {
     echo
   fi
 
-  return ${showExitCode}
+  mainExitCode=${showExitCode}
 }

--- a/src/terragrunt_show.sh
+++ b/src/terragrunt_show.sh
@@ -8,7 +8,7 @@ function terragruntShow {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${showExitCode} -eq 0 ]; then

--- a/src/terragrunt_taint.sh
+++ b/src/terragrunt_taint.sh
@@ -8,6 +8,10 @@ function terragruntTaint {
   taintExitCode=${?}
   taintCommentStatus="Failed"
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${taintExitCode} -eq 0 ]; then
     taintCommentStatus="Success"

--- a/src/terragrunt_taint.sh
+++ b/src/terragrunt_taint.sh
@@ -8,17 +8,13 @@ function terragruntTaint {
   taintExitCode=${?}
   taintCommentStatus="Failed"
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${taintExitCode} -eq 0 ]; then
     taintCommentStatus="Success"
     echo "taint: info: successfully tainted Terragrunt configuration in ${tfWorkingDir}"
     echo "${taintOutput}"
     echo
-    exit ${taintExitCode}
+    return ${taintExitCode}
   fi
 
   # Exit code of !0 indicates failure.
@@ -49,5 +45,5 @@ ${taintOutput}
     echo "${taintPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${taintCommentsURL}" > /dev/null
   fi
 
-  exit ${taintExitCode}
+  return ${taintExitCode}
 }

--- a/src/terragrunt_taint.sh
+++ b/src/terragrunt_taint.sh
@@ -14,7 +14,8 @@ function terragruntTaint {
     echo "taint: info: successfully tainted Terragrunt configuration in ${tfWorkingDir}"
     echo "${taintOutput}"
     echo
-    return ${taintExitCode}
+    mainExitCode=${taintExitCode}
+    return
   fi
 
   # Exit code of !0 indicates failure.
@@ -45,5 +46,5 @@ ${taintOutput}
     echo "${taintPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${taintCommentsURL}" > /dev/null
   fi
 
-  return ${taintExitCode}
+  mainExitCode=${taintExitCode}
 }

--- a/src/terragrunt_taint.sh
+++ b/src/terragrunt_taint.sh
@@ -10,7 +10,7 @@ function terragruntTaint {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${taintExitCode} -eq 0 ]; then

--- a/src/terragrunt_validate.sh
+++ b/src/terragrunt_validate.sh
@@ -11,7 +11,8 @@ function terragruntValidate {
     echo "validate: info: successfully validated Terragrunt configuration in ${tfWorkingDir}"
     echo "${validateOutput}"
     echo
-    return ${validateExitCode}
+    mainExitCode=${validateExitCode}
+    return
   fi
 
   # Exit code of !0 indicates failure.
@@ -37,5 +38,5 @@ ${validateOutput}
     echo "${validatePayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${validateCommentsURL}" > /dev/null
   fi
 
-  return ${validateExitCode}
+  mainExitCode=${validateExitCode}
 }

--- a/src/terragrunt_validate.sh
+++ b/src/terragrunt_validate.sh
@@ -6,16 +6,12 @@ function terragruntValidate {
   validateOutput=$(${tfBinary} validate ${*} 2>&1)
   validateExitCode=${?}
 
-  # Pass the directory used for processing terraform to the outputs
-  terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
-
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${validateExitCode} -eq 0 ]; then
     echo "validate: info: successfully validated Terragrunt configuration in ${tfWorkingDir}"
     echo "${validateOutput}"
     echo
-    exit ${validateExitCode}
+    return ${validateExitCode}
   fi
 
   # Exit code of !0 indicates failure.
@@ -41,5 +37,5 @@ ${validateOutput}
     echo "${validatePayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${validateCommentsURL}" > /dev/null
   fi
 
-  exit ${validateExitCode}
+  return ${validateExitCode}
 }

--- a/src/terragrunt_validate.sh
+++ b/src/terragrunt_validate.sh
@@ -8,7 +8,7 @@ function terragruntValidate {
 
   # Pass the directory used for processing terraform to the outputs
   terraformDir=$(findTerraformDir)
-  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+  echo "tf_actions_terraform_dir=${terraformDir}" >> ${GITHUB_OUTPUT}
 
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${validateExitCode} -eq 0 ]; then

--- a/src/terragrunt_validate.sh
+++ b/src/terragrunt_validate.sh
@@ -6,6 +6,10 @@ function terragruntValidate {
   validateOutput=$(${tfBinary} validate ${*} 2>&1)
   validateExitCode=${?}
 
+  # Pass the directory used for processing terraform to the outputs
+  terraformDir=$(findTerraformDir)
+  echo "tf_actions_terraform_dir='${terraformDir}'" >> ${GITHUB_OUTPUT}
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${validateExitCode} -eq 0 ]; then
     echo "validate: info: successfully validated Terragrunt configuration in ${tfWorkingDir}"


### PR DESCRIPTION
Adding an output that represents the directory where terraform was executed from as part of the call to execute terragrunt.  This is required to allow other tools to use the terraform code to enhance their own execution.  Example: Checkov can provide skip functionality via comments but only if it can read the raw TF code.

The output directory is pathed starting at the `.terragrunt-cache/` directory and will extend down to the actual directory executed within.

Tests performed with this workflow change:
- Directory discovery with remote module (different repo)
- Directory discovery with local module (same repo)